### PR TITLE
Include config/customization in image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -39,8 +39,6 @@ services:
       - ./volumes/cryptpad/block:/cryptpad/block
       - ./volumes/cryptpad/data:/cryptpad/data
       - ./volumes/cryptpad/files:/cryptpad/datastore
-      - ./config/config.js:/cryptpad/config/config.js:ro
-      - ./customize:/cryptpad/customize.local:ro
     expose:
       - "3000"
       - "3003"

--- a/docker/cryptpad/.bumpversion.toml
+++ b/docker/cryptpad/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2025.9.4+260614"
+current_version = "2025.9.4+260702"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/docker/cryptpad/Dockerfile
+++ b/docker/cryptpad/Dockerfile
@@ -40,6 +40,8 @@ WORKDIR /cryptpad
 COPY --from=build --chown=cryptpad:cryptpad /src /cryptpad
 COPY --chown=cryptpad:cryptpad docker/cryptpad/docker-entrypoint.sh /usr/local/bin/cryptpad-entrypoint.sh
 COPY --chown=cryptpad:cryptpad config/sso.js /cryptpad/config/sso.js
+COPY --chown=cryptpad:cryptpad config/config.js /cryptpad/config/config.js
+COPY --chown=cryptpad:cryptpad customize /cryptpad/customize.local
 
 RUN chmod 0755 /usr/local/bin/cryptpad-entrypoint.sh \
     && mkdir -p /cryptpad/blob /cryptpad/block /cryptpad/customize /cryptpad/data /cryptpad/datastore \

--- a/docker/cryptpad/docker-entrypoint.sh
+++ b/docker/cryptpad/docker-entrypoint.sh
@@ -60,4 +60,10 @@ if [ ! -f "$CPAD_DECREE_FILE" ] || ! grep -q '"SET_BEARER_SECRET"' "$CPAD_DECREE
   " "$CPAD_DECREE_FILE" "$bearer_secret" "$decree_time"
 fi
 
+# One-shot boolean decrees; appended once, then persisted in the data volume.
+for config in REMOVE_DONATE_BUTTON BLOCK_DAILY_CHECK; do
+  grep -q "\"$config\"" "$CPAD_DECREE_FILE" 2>/dev/null && continue
+  printf '["%s",[true],"INTERNAL",%s]\n' "$config" "$(node -e 'process.stdout.write(String(Date.now()))')" >> "$CPAD_DECREE_FILE"
+done
+
 exec "$@"

--- a/rmcryptpad/.bumpversion.toml
+++ b/rmcryptpad/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.0.0+260614"
+current_version = "1.0.1+260702"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"
@@ -33,3 +33,8 @@ replace = 'version = "{new_version}"'
 filename = "src/rmcryptpad/__init__.py"
 search = '__version__ = "{current_version}"'
 replace = '__version__ = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "tests/test_package.py"
+search = '__version__ == "{current_version}"'
+replace = '__version__ == "{new_version}"'

--- a/rmcryptpad/pyproject.toml
+++ b/rmcryptpad/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rmcryptpad"
-version = "1.0.0+260614"
+version = "1.0.1+260702"
 description = "Deploy App integration layer for CryptPad"
 authors = ["ElderX <elderx@example.com>"]
 readme = "README.md"

--- a/rmcryptpad/src/rmcryptpad/__init__.py
+++ b/rmcryptpad/src/rmcryptpad/__init__.py
@@ -1,3 +1,3 @@
 """rmcryptpad package."""
 
-__version__ = "1.0.0+260614"
+__version__ = "1.0.1+260702"

--- a/rmcryptpad/src/rmcryptpad/config.py
+++ b/rmcryptpad/src/rmcryptpad/config.py
@@ -58,6 +58,10 @@ class RMCryptPadSettings(BaseSettings):
     docs_url: str = "https://docs.cryptpad.org/en/admin_guide/installation.html"
     ui_dir: str = "/opt/ui/cryptpad"
     oidc_issuer: str = "https://rmcryptpad.localhost:8443"
+    oidc_internal_url: Optional[str] = Field(
+        default=None,
+        description="Base URL for server to server OIDC calls, if empty oidc_issuer is used.",
+    )
     oidc_key_dir: str = "/data/oidc"
     oidc_client_id: str = "cryptpad"
     oidc_client_secret: str = "cryptpad-secret"

--- a/rmcryptpad/src/rmcryptpad/oidc/service.py
+++ b/rmcryptpad/src/rmcryptpad/oidc/service.py
@@ -62,12 +62,15 @@ class OIDCProvider:
 
     def discovery_document(self) -> dict[str, Any]:
         """Return the OpenID Connect discovery document."""
+        backchannel = (
+            self.settings.oidc_internal_url or self.settings.oidc_issuer
+        ).rstrip("/")
         return {
             "issuer": self.issuer,
             "authorization_endpoint": f"{self.issuer}/oidc/authorize",
-            "token_endpoint": f"{self.issuer}/oidc/token",
-            "userinfo_endpoint": f"{self.issuer}/oidc/userinfo",
-            "jwks_uri": f"{self.issuer}/oidc/jwks.json",
+            "token_endpoint": f"{backchannel}/oidc/token",
+            "userinfo_endpoint": f"{backchannel}/oidc/userinfo",
+            "jwks_uri": f"{backchannel}/oidc/jwks.json",
             "response_types_supported": ["code"],
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256"],

--- a/rmcryptpad/tests/test_oidc.py
+++ b/rmcryptpad/tests/test_oidc.py
@@ -69,6 +69,31 @@ def test_discovery_document_returns_expected_urls(
     assert payload["jwks_uri"].endswith("/oidc/jwks.json")
 
 
+def test_discovery_document_uses_internal_url_for_backchannel(
+    dbinstance: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Verify backchannel endpoints use the internal URL while issuer stays external."""
+    _ = dbinstance
+    _configure_oidc(monkeypatch, tmp_path)
+    monkeypatch.setenv("RMCRYPTPAD_OIDC_INTERNAL_URL", "http://127.0.0.1:8000")
+    RMCryptPadSettings._singleton = None  # pylint: disable=protected-access
+    app = get_app_no_init()
+
+    with TestClient(app) as client:
+        response = client.get("/.well-known/openid-configuration")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["issuer"] == "https://rmcryptpad.localhost:8443"
+    assert (
+        payload["authorization_endpoint"]
+        == "https://rmcryptpad.localhost:8443/oidc/authorize"
+    )
+    assert payload["token_endpoint"] == "http://127.0.0.1:8000/oidc/token"
+    assert payload["userinfo_endpoint"] == "http://127.0.0.1:8000/oidc/userinfo"
+    assert payload["jwks_uri"] == "http://127.0.0.1:8000/oidc/jwks.json"
+
+
 def test_authorize_rejects_missing_or_revoked_active_callsign(
     dbinstance: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/rmcryptpad/tests/test_package.py
+++ b/rmcryptpad/tests/test_package.py
@@ -6,7 +6,7 @@ from rmcryptpad.config import RMCryptPadSettings
 
 def test_version() -> None:
     """Verify the package version string."""
-    assert __version__ == "1.0.0+260614"
+    assert __version__ == "1.0.1+260702"
 
 
 def test_settings_defaults() -> None:


### PR DESCRIPTION
## User-Facing Summary
- Include config + customization in image
- Configured cryptpad:
  - Disabled daily check to cryptpad
  - Hid donate button from users 

## Why It's Good for the Product (Release Goal)
- K8s can implement cryptpad without having to copy the files.
- Less information to third parties
